### PR TITLE
De-list unsupported EVENTS from TorControlCommands and add exception handling

### DIFF
--- a/src/net/freehaven/tor/control/EventListener.java
+++ b/src/net/freehaven/tor/control/EventListener.java
@@ -32,7 +32,6 @@ public abstract class EventListener implements RawEventListener {
      * <li>{@link TorControlCommands#EVENT_GUARD}</li>
      * <li>{@link TorControlCommands#EVENT_STREAM_BANDWIDTH_USED}</li>
      * <li>{@link TorControlCommands#EVENT_CLIENTS_SEEN}</li>
-     * <li>{@link TorControlCommands#EVENT_NEWCONSENSUS}</li>
      * <li>{@link TorControlCommands#EVENT_BUILDTIMEOUT_SET}</li>
      * <li>{@link TorControlCommands#EVENT_GOT_SIGNAL}</li>
      * <li>{@link TorControlCommands#EVENT_CONF_CHANGED}</li>
@@ -41,7 +40,6 @@ public abstract class EventListener implements RawEventListener {
      * <li>{@link TorControlCommands#EVENT_CIRC_BANDWIDTH_USED}</li>
      * <li>{@link TorControlCommands#EVENT_TRANSPORT_LAUNCHED}</li>
      * <li>{@link TorControlCommands#EVENT_HS_DESC}</li>
-     * <li>{@link TorControlCommands#EVENT_HS_DESC_CONTENT}</li>
      * <li>{@link TorControlCommands#EVENT_NETWORK_LIVENESS}</li>
      * </ul>
      *
@@ -109,9 +107,9 @@ public abstract class EventListener implements RawEventListener {
             case TorControlCommands.EVENT_CLIENTS_SEEN:
                 clientsSeen(data);
                 break;
-            case TorControlCommands.EVENT_NEWCONSENSUS:
-                newConsensus(data);
-                break;
+//            case TorControlCommands.EVENT_NEWCONSENSUS:
+//                newConsensus(data);
+//                break;
             case TorControlCommands.EVENT_BUILDTIMEOUT_SET:
                 buildTimeoutSet(data);
                 break;
@@ -136,9 +134,9 @@ public abstract class EventListener implements RawEventListener {
             case TorControlCommands.EVENT_HS_DESC:
                 hsDesc(data);
                 break;
-            case TorControlCommands.EVENT_HS_DESC_CONTENT:
-                hsDescContent(data);
-                break;
+//            case TorControlCommands.EVENT_HS_DESC_CONTENT:
+//                hsDescContent(data);
+//                break;
             case TorControlCommands.EVENT_NETWORK_LIVENESS:
                 networkLiveness(data);
                 break;
@@ -187,7 +185,7 @@ public abstract class EventListener implements RawEventListener {
 
     public abstract void clientsSeen(String data);
 
-    public abstract void newConsensus(String data);
+//    public abstract void newConsensus(String data);
 
     public abstract void buildTimeoutSet(String data);
 
@@ -205,7 +203,7 @@ public abstract class EventListener implements RawEventListener {
 
     public abstract void hsDesc(String data);
 
-    public abstract void hsDescContent(String data);
+//    public abstract void hsDescContent(String data);
 
     public abstract void networkLiveness(String data);
 

--- a/src/net/freehaven/tor/control/RawEventListener.java
+++ b/src/net/freehaven/tor/control/RawEventListener.java
@@ -32,7 +32,6 @@ public interface RawEventListener {
      * <li>{@link TorControlCommands#EVENT_GUARD}</li>
      * <li>{@link TorControlCommands#EVENT_STREAM_BANDWIDTH_USED}</li>
      * <li>{@link TorControlCommands#EVENT_CLIENTS_SEEN}</li>
-     * <li>{@link TorControlCommands#EVENT_NEWCONSENSUS}</li>
      * <li>{@link TorControlCommands#EVENT_BUILDTIMEOUT_SET}</li>
      * <li>{@link TorControlCommands#EVENT_GOT_SIGNAL}</li>
      * <li>{@link TorControlCommands#EVENT_CONF_CHANGED}</li>
@@ -41,7 +40,6 @@ public interface RawEventListener {
      * <li>{@link TorControlCommands#EVENT_CIRC_BANDWIDTH_USED}</li>
      * <li>{@link TorControlCommands#EVENT_TRANSPORT_LAUNCHED}</li>
      * <li>{@link TorControlCommands#EVENT_HS_DESC}</li>
-     * <li>{@link TorControlCommands#EVENT_HS_DESC_CONTENT}</li>
      * <li>{@link TorControlCommands#EVENT_NETWORK_LIVENESS}</li>
      * </ul>
      *

--- a/src/net/freehaven/tor/control/TorControlCommands.java
+++ b/src/net/freehaven/tor/control/TorControlCommands.java
@@ -170,7 +170,7 @@ public interface TorControlCommands {
         "GUARD",
         "STREAM_BW",
         "CLIENTS_SEEN",
-        "NEWCONSENSUS",
+//        "NEWCONSENSUS",
         "BUILDTIMEOUT_SET",
         "SIGNAL",
         "CONF_CHANGED",
@@ -179,7 +179,7 @@ public interface TorControlCommands {
         "CIRC_BW",
         "TRANSPORT_LAUNCHED",
         "HS_DESC",
-        "HS_DESC_CONTENT",
+//        "HS_DESC_CONTENT",
         "NETWORK_LIVENESS"
     };
 
@@ -203,7 +203,7 @@ public interface TorControlCommands {
     public static final String EVENT_GUARD = "GUARD";
     public static final String EVENT_STREAM_BANDWIDTH_USED = "STREAM_BW";
     public static final String EVENT_CLIENTS_SEEN = "CLIENTS_SEEN";
-    public static final String EVENT_NEWCONSENSUS = "NEWCONSENSUS";
+//    public static final String EVENT_NEWCONSENSUS = "NEWCONSENSUS";
     public static final String EVENT_BUILDTIMEOUT_SET = "BUILDTIMEOUT_SET";
     public static final String EVENT_GOT_SIGNAL = "SIGNAL";
     public static final String EVENT_CONF_CHANGED = "CONF_CHANGED";
@@ -212,7 +212,7 @@ public interface TorControlCommands {
     public static final String EVENT_CIRC_BANDWIDTH_USED = "CIRC_BW";
     public static final String EVENT_TRANSPORT_LAUNCHED = "TRANSPORT_LAUNCHED";
     public static final String EVENT_HS_DESC = "HS_DESC";
-    public static final String EVENT_HS_DESC_CONTENT = "HS_DESC_CONTENT";
+//    public static final String EVENT_HS_DESC_CONTENT = "HS_DESC_CONTENT";
     public static final String EVENT_NETWORK_LIVENESS = "NETWORK_LIVENESS";
 
     public static final byte CIRC_STATUS_LAUNCHED = 0x01;

--- a/src/net/freehaven/tor/control/TorControlConnection.java
+++ b/src/net/freehaven/tor/control/TorControlConnection.java
@@ -15,6 +15,7 @@ import java.io.Writer;
 import java.net.Socket;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -561,7 +562,6 @@ public class TorControlConnection implements TorControlCommands {
      * <li>{@link TorControlCommands#EVENT_GUARD}: "GUARD"</li>
      * <li>{@link TorControlCommands#EVENT_STREAM_BANDWIDTH_USED}: "STREAM_BW"</li>
      * <li>{@link TorControlCommands#EVENT_CLIENTS_SEEN}: "CLIENTS_SEEN"</li>
-     * <li>{@link TorControlCommands#EVENT_NEWCONSENSUS}: "NEWCONSENSUS"</li>
      * <li>{@link TorControlCommands#EVENT_BUILDTIMEOUT_SET}: "BUILDTIMEOUT_SET"</li>
      * <li>{@link TorControlCommands#EVENT_GOT_SIGNAL}: "SIGNAL"</li>
      * <li>{@link TorControlCommands#EVENT_CONF_CHANGED}: "CONF_CHANGED"</li>
@@ -570,7 +570,6 @@ public class TorControlConnection implements TorControlCommands {
      * <li>{@link TorControlCommands#EVENT_CIRC_BANDWIDTH_USED}: "CIRC_BW"</li>
      * <li>{@link TorControlCommands#EVENT_TRANSPORT_LAUNCHED}: "TRANSPORT_LAUNCHED"</li>
      * <li>{@link TorControlCommands#EVENT_HS_DESC}: "HS_DESC"</li>
-     * <li>{@link TorControlCommands#EVENT_HS_DESC_CONTENT}: "HS_DESC_CONTENT"</li>
      * <li>{@link TorControlCommands#EVENT_NETWORK_LIVENESS}: "NETWORK_LIVENESS"</li>
      * </ul>
      * Any events not listed in the <b>events</b> are turned off; thus, calling
@@ -580,8 +579,13 @@ public class TorControlConnection implements TorControlCommands {
      */
     public void setEvents(List<String> events) throws IOException {
         StringBuffer sb = new StringBuffer(SETEVENTS);
+        String supportedEvents = Arrays.toString(EVENT_NAMES);
         for (Iterator<String> it = events.iterator(); it.hasNext(); ) {
-            sb.append(" ").append(it.next());
+            String event = it.next();
+            if (!supportedEvents.contains(event)) {
+                throw new IllegalArgumentException("Event: "+event+" is not yet implemented");
+            }
+            sb.append(" ").append(event);
         }
         sb.append("\r\n");
         sendAndWaitForResponse(sb.toString(), null);

--- a/src/net/freehaven/tor/control/TorControlConnection.java
+++ b/src/net/freehaven/tor/control/TorControlConnection.java
@@ -13,6 +13,7 @@ import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.net.Socket;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -225,8 +226,16 @@ public class TorControlConnection implements TorControlCommands {
         for (Iterator<ReplyLine> i = events.iterator(); i.hasNext(); ) {
             ReplyLine line = i.next();
             int idx = line.msg.indexOf(' ');
-            String tp = line.msg.substring(0, idx).toUpperCase();
-            String rest = line.msg.substring(idx + 1);
+            String tp;
+            String rest;
+            try {
+                tp = line.msg.substring(0, idx).toUpperCase();
+                rest = line.msg.substring(idx + 1);
+            } catch (StringIndexOutOfBoundsException ex) {
+                throw new UnsupportedOperationException(
+                        "Event listened for is not yet implemented" , ex
+                );
+            }
             for (RawEventListener rawEventListener : rawEventListeners) {
                 rawEventListener.onEvent(tp, rest);
             }

--- a/src/net/freehaven/tor/control/TorControlConnection.java
+++ b/src/net/freehaven/tor/control/TorControlConnection.java
@@ -219,7 +219,7 @@ public class TorControlConnection implements TorControlCommands {
      * {@link EventHandler} is set, then decode the event arguments and send
      * call the {@code EventHandler} methods.
      */
-    protected void handleEvent(ArrayList<ReplyLine> events) {
+    protected void handleEvent(ArrayList<ReplyLine> events) throws UnsupportedOperationException {
         if (handler == null && rawEventListeners.isEmpty()) {
             return;
         }
@@ -577,7 +577,7 @@ public class TorControlConnection implements TorControlCommands {
      *
      * @see <a href="https://torproject.gitlab.io/torspec/control-spec/#setevents">control-spec: SETEVENTS</a>
      */
-    public void setEvents(List<String> events) throws IOException {
+    public void setEvents(List<String> events) throws IOException, IllegalArgumentException {
         StringBuffer sb = new StringBuffer(SETEVENTS);
         String supportedEvents = Arrays.toString(EVENT_NAMES);
         for (Iterator<String> it = events.iterator(); it.hasNext(); ) {

--- a/test/net/freehaven/tor/control/TorControlConnectionTest.java
+++ b/test/net/freehaven/tor/control/TorControlConnectionTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TorControlConnectionTest {
 
@@ -127,6 +128,14 @@ public class TorControlConnectionTest {
         torControlConnection.launchThread(true);
         torControlConnection.authenticate(new byte[0]);
         torControlConnection.setEventHandler(eventHandler);
+
+        try {
+            torControlConnection.setEvents(Arrays.asList(
+                    "NEWCONSENSUS", TorControlCommands.EVENT_CONN_BW
+            ));
+            fail();
+        } catch (IllegalArgumentException ignored) {}
+
         torControlConnection.setEvents(Arrays.asList(
                 TorControlCommands.EVENT_OR_CONN_STATUS,
                 TorControlCommands.EVENT_CIRCUIT_STATUS,


### PR DESCRIPTION
This PR:
 - Comments out `TorControlCommands` EVENTS who's syntax (according to the <a href="https://torproject.gitlab.io/torspec/control-spec.html#asynchronous-events" target="_blank">torspec</a>) start with `"650" "+"` and end with `CRLF "650" SP "OK" CRLF`.
 - Comments out processing of these EVENTS from the `EventListener`.
 - Adds exception handling in the event of processing a not yet implemented command in the `TorControlConnection.handleEvent()`.
     - Now throws an `UnsupportedOperationException` with more descriptive message of the cause.
 - Throws a new `IllegalArgumentException` in `TorControlConnection.setEvents()` if an event being passed is not contained in `TorControlCommands.EVENT_NAMES`.
     - Integrates into the `test()` a check to ensure `IllegalArgumentException` is being thrown properly.

See comments in <a href="https://github.com/05nelsonm/TorOnionProxyLibrary-Android/issues/14" target="_blank">this issue</a> for further context.